### PR TITLE
Remove main property from fs-components package.json

### DIFF
--- a/packages/fs-components/package.json
+++ b/packages/fs-components/package.json
@@ -1,8 +1,6 @@
 {
   "name": "fs-components",
   "version": "1.0.0",
-  "main": "index.ts",
-  "license": "MIT",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.18.9",


### PR DESCRIPTION
This PR resolves #18 

This just removes main from the properties of fs-component's package.json. It doesn't fix any problem but removes redundancies.